### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ Agents facilitate the interaction from clients with canisters on the Internet Co
 ### Dart/Flutter
 
 - [agent_dart](https://github.com/AstroxNetwork/agent_dart) - Framework to build mobile applications.
-- [ic_dart_tools](https://github.com/levifeldman/ic_tools_dart) - Tools supporting Flutter on the web.
+- [ic_tools](https://github.com/levifeldman/ic_tools) - IC Tools supporting Dart & Flutter on the web and linux.
+- [ic_tools_web](https://github.com/levifeldman/ic_tools_web) - Library with specific tools for Flutter on the Web.  
 
 ### Go
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Agents facilitate the interaction from clients with canisters on the Internet Co
 ### Dart/Flutter
 
 - [agent_dart](https://github.com/AstroxNetwork/agent_dart) - Framework to build mobile applications.
-- [ic_tools](https://github.com/levifeldman/ic_tools) - IC Tools supporting Dart & Flutter on the web and linux.
+- [ic_tools](https://github.com/levifeldman/ic_tools) - IC Tools supporting Dart & Flutter on the Web and Linux.
 - [ic_tools_web](https://github.com/levifeldman/ic_tools_web) - Library with specific tools for Flutter on the Web.  
 
 ### Go


### PR DESCRIPTION
Update the description of the Dart ic_tools library to clarify that the library can run on Dart code by itself and on a linux desktop. 

Add the ic_tools_web library which contains specific tools and classes for the Flutter-Web platform such as a Caller class using the SubtleCrypto export=false browser api, and an internet-identity login function.