### PR TITLE
Add ic-oxigraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Candid is an interface description language (IDL) for interacting with canisters
 ## Storage and Databases
 
 - [CanDB](https://github.com/ORIGYN-SA/CanDB) - Flexible, performant, and horizontally scalable non-relational multi-canister database built in Motoko.
+- [ic-oxigraph](https://github.com/omnia-network/ic-oxigraph) - An RDF database for the IC, that enables on-chain knowledge graphs.
 - [ic-sqlite](https://github.com/froghub-io/ic-sqlite) - SQLite on the IC.
 - [ic-stable-memory](https://github.com/seniorjoinu/ic-stable-memory) - Stable memory collections for Rust.
 - [stable-structures](https://github.com/dfinity/stable-structures) - A collection of scalable and upgrade-safe data structures for Rust maintained by DFINITY.


### PR DESCRIPTION
[RDF](https://www.w3.org/TR/rdf11-concepts/) databases enable the creation of knowledge graphs. With ic-oxigraph, the knowledge graph can be hosted on the IC and, thanks to the IC HTTP Gateway, a [SPARQL](https://www.w3.org/TR/sparql11-overview/) endpoint can be exposed directly from the canister.