### PR TITLE
Add Open Internet Metaverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,10 @@ For Unity-compatible client libraries, see [C# agents](#C#).
 
 - [icpp-llm](https://github.com/icppWorld/icpp-llm) - LLMs for the Internet Computer.
 
+## Metaverse
+
+- [Open Internet Metaverse](https://github.com/Bebb-Protocol-and-Apps/PWS) - Easily create your personal virtual space and host it like a 3D Website ("Webspace") on the Internet Computer. [Try it here](https://vdfyi-uaaaa-aaaai-acptq-cai.ic0.app/)
+
 ## How it works / Deep dives
 
 - [Internet Computer for Geeks](https://internetcomputer.org/whitepaper.pdf) - Whitepaper written by the DFINITY team.


### PR DESCRIPTION
This adds the Open Internet Metaverse (OIM) app as a first example to the new Metaverse section. OIM allows users to create virtual spaces and host them like Websites on the Internet Computer - everything in 3D though. Users can include 3D objects, images, videos and more in their spaces and thus make it their home on the 3D Web. In addition, they can link to others' spaces and create their personal virtual neighborhood in the "Metaverse" (aka Internet). Thank you.