### PR TITLE
Add Web3 with TypeScript Bootcamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The [Internet Computer](https://internetcomputer.org/) is a public blockchain th
 - [Web3, Blockchain and the Internet Computer](https://www.youtube.com/playlist?list=PLSzsOkUDsvdubXF5XGGPffyQJ5CVU_9_c) - Youtube series (excerpt from The Complete Web Development Bootcamp).
 - [AgorApp Motoko Course](https://agorapp.dev/editor/courses/motoko/learn-motoko/01-variables) - Interactive course for Motoko beginners.
 - [Dacade TypeScript Smart Contract 101](https://dacade.org/communities/icp/) - Learn to build Dapps on the IC using TypeScript.
+- [Web3 with TypeScript Bootcamp](https://github.com/Code-and-State/typescript-bootcamp) - Learn to build a DAO in 7 days, with TypeScript, on the Internet Computer.
 
 ### Tutorials and Samples
 


### PR DESCRIPTION
The Web3 with TypeScript Bootcamp took place from August 21st to August 27th. We've uploaded all relevant materials to the repository, which includes:

- **10 Workshops:** Aimed at helping beginners get started with ICP and Azle.

- **7 Daily Guides**: These provide step-by-step assistance and advice for building your project.

- **Project Template**s: We offer templates specifically designed for major front-end frameworks such as Svelte. You'll also find project requirements to kickstart your DAO development.

- **Curated Educational Resources**: A handpicked list of useful educational materials to aid your learning journey.

- **Discord Access**: Join our Discord channel for ongoing support and mentorship from experts in the field.