### PR TITLE
Add link to SaorsaLabs template canister repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The [Internet Computer](https://internetcomputer.org/) is a public blockchain th
 - [Rust + React (Typescript) + Internet Identity](https://medium.com/@ilbert/rust-react-typescript-internet-identity-on-the-internet-computer-35331ae2a4be) - Tutorial on setting up a project with Rust, React and Internet Identity.
 - [C++ ](https://docs.icpp.world/getting-started.html) - Introduction to developing canisters in C++.
 - [WebSockets on the Internet Computer: Getting Started](https://medium.com/@ilbert/websockets-on-the-ic-getting-started-5f8bcdfaabdc) - Tutorial on setting up a WebSocket connection from a frontend client to a canister.
+- [Rust Modular Canister Template](https://github.com/SaorsaLabs/Template_Canister) - An example canister with stable storage, HTTP outcalls, timers and more.
   
 #### Advanced
 
@@ -94,8 +95,7 @@ The [Internet Computer](https://internetcomputer.org/) is a public blockchain th
 - [IC in Dev Container](https://github.com/infu/internet-computer-start) - Run a local replica inside a Docker container with NNS in VS Code or GitHub Codespaces.
 - [ic-eth-starter](https://github.com/dfinity/ic-eth-starter) - An advanced starter project for interacting with Ethereum on the Internet Computer (Beta).
 - [IC Rust NextJS Starter](https://github.com/b3hr4d/ic-rust-nextjs) - A starter kit for building applications with Rust and Next.js on the Internet Computer.
-- [Azle + NextJS Starter](https://github.com/mzurs/ic_template-Azle-NextJS) - Build Full-stack Dapp on IC with Typescript CDK and NextJS
-- [Rust Modular Canister Template](https://github.com/SaorsaLabs/Template_Canister) - An example canister with stable storage, HTTP outcalls, timers and more.
+- [Azle + NextJS Starter](https://github.com/mzurs/ic_template-Azle-NextJS) - Build Full-stack Dapp on IC with Typescript CDK and NextJS.
 
 ## Client Libraries (Agents)
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The [Internet Computer](https://internetcomputer.org/) is a public blockchain th
 - [ic-eth-starter](https://github.com/dfinity/ic-eth-starter) - An advanced starter project for interacting with Ethereum on the Internet Computer (Beta).
 - [IC Rust NextJS Starter](https://github.com/b3hr4d/ic-rust-nextjs) - A starter kit for building applications with Rust and Next.js on the Internet Computer.
 - [Azle + NextJS Starter](https://github.com/mzurs/ic_template-Azle-NextJS) - Build Full-stack Dapp on IC with Typescript CDK and NextJS
+- [Rust Modular Canister Template](https://github.com/SaorsaLabs/Template_Canister) - An example canister with stable storage, HTTP outcalls, timers and more.
 
 ## Client Libraries (Agents)
 


### PR DESCRIPTION
Readme has been updated with a link to a Rust Template Canister repo created by Saorsa Labs. Full stop added to end of Azle link text.