### PR TITLE
Add 'ic-oss' to 'Storage' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Candid is an interface description language (IDL) for interacting with canisters
 - [stable-structures](https://github.com/dfinity/stable-structures) - A collection of scalable and upgrade-safe data structures for Rust maintained by DFINITY.
 - [Sudograph](https://github.com/sudograph/sudograph) - A GraphQL database for the IC.
 - [Certified Blockchain](https://github.com/Factland/ic-certified-blockchain) - Certified blockchain log on on the IC.  This can be validated using only the NNS public key: [Validation](https://github.com/Factland/certified-blockchain-verification).
+- [ic-oss](https://github.com/ldclabs/ic-oss) - A decentralized Object Storage Service on the IC.
 
 ## Infrastructure
 


### PR DESCRIPTION
Hi, @letmejustputthishere , ic-oss will become the decentralized alternative to Amazon S3.
