### PR TITLE
Added Windoge98 Plug-n-Play

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ For Unreal Engine-compatible client libraries, see [C++ agents](#C++).
 
 ### Libraries
 
+- [Plug-n-Play](https://github.com/microdao-corporation/plug-n-play) – A lightweight, framework-agnostic, wallet adapter that implements ICRC auth standards.
 - [artemis](https://github.com/sonicdex/artemis) – Wallet adapter for connecting different wallets on the Internet Computer.
 - [ic-siwe](https://github.com/kristoferlund/ic-siwe) - Authentication library to enable SIWE (Sign in with Ethereum) functionality for ICP applications.
 - [ic-siws](https://github.com/kristoferlund/ic-siws) – Authentication library to enable SIWS (Sign in with Solana) functionality for ICP applications.


### PR DESCRIPTION
Plug-N-Play is a framework agnostic typescript library by the Windoge98 team that makes setting up authentication on the IC easy while also using the ICRC auth standards. 
