### PR TITLE
Adds DAO_Backend by TacoDao

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ Candid is an interface description language (IDL) for interacting with canisters
 - [Service Nervous System](https://internetcomputer.org/sns) - Framework inspired by the Network Nervous System.
 - [Threshold Canister](https://github.com/dfinity/threshold) - Threshold voting and execution for the IC.
 - [ICP Governance Canister](https://github.com/redsteep/dfinity-icp-governor) - A fully-fledged single DAO governance solution inspired by the Compound smart contracts.
+- [DAO_Backend by TacoDao](https://github.com/tacodaoicp/DAO_Backend) - A framework designed for continuous allocation voting and treasury management.
 
 ## Game Development
 


### PR DESCRIPTION
- TacoDao is an Internet Computer SNS project
- The DAO_Backend project was successfully audited by https://x.com/afat
- I've included "by Taco Dao" in the description to disambiguate the link title "DAO_Backend"