### PR TITLE
Add Canister DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Agents facilitate the interaction from clients with canisters on the Internet Co
 - [wasi2ic](https://github.com/wasm-forge/wasi2ic) - Convert WASI binaries into binaries runnable on the IC.
 - [setup-dfx](https://github.com/dfinity/setup-dfx) – GitHub Action to set up dfx
 - [ICP Support](https://marketplace.visualstudio.com/items?itemName=blockydevs.vscode-motoko-helper) - VS Code extension for deploying and interacting with canisters directly from within the editor.
+- [Canister DNS](https://canisterdns.stevekimoi.me) - A tool to easily connect your custom domain to your canister URL, supporting both main domains and subdomains.
 
 ### Testing
 


### PR DESCRIPTION
Add Canister DNS - a toolkit that allows someone to easily link their canister to their domain in a matter of seconds.